### PR TITLE
update currency converter to v1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "bytebuffer": "^5.0.1",
         "chart.js": "^3.8.0",
         "chartjs-plugin-datalabels": "^2.0.0",
-        "currency-converter-lt": "^1.2.4",
+        "currency-converter-lt": "^1.3.0",
         "custom-electron-titlebar": "^4.1.0",
         "electron-debug": "^3.2.0",
         "electron-dl": "^3.3.0",
@@ -6082,9 +6082,9 @@
       "integrity": "sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs="
     },
     "node_modules/currency-converter-lt": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/currency-converter-lt/-/currency-converter-lt-1.2.4.tgz",
-      "integrity": "sha512-WQkafMYeH7Wma/kD1NveMR5PHKXrMw+01OvpKFm1xQi+DLYPnnWmT9/P/sqzifp1wd3yuoxRnc5WoFYwAqFnKA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/currency-converter-lt/-/currency-converter-lt-1.3.0.tgz",
+      "integrity": "sha512-u4CkP9eaYJAghSPX9h8YkWQGRJ82ncgyMojje55ts2WSwM/e36ss3WxpJ2PlrY0ZPUQUa1UnvDt2PrRBDBLhsQ==",
       "dependencies": {
         "cheerio": "latest",
         "got": "11.8.2"
@@ -23323,9 +23323,9 @@
       "integrity": "sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs="
     },
     "currency-converter-lt": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/currency-converter-lt/-/currency-converter-lt-1.2.4.tgz",
-      "integrity": "sha512-WQkafMYeH7Wma/kD1NveMR5PHKXrMw+01OvpKFm1xQi+DLYPnnWmT9/P/sqzifp1wd3yuoxRnc5WoFYwAqFnKA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/currency-converter-lt/-/currency-converter-lt-1.3.0.tgz",
+      "integrity": "sha512-u4CkP9eaYJAghSPX9h8YkWQGRJ82ncgyMojje55ts2WSwM/e36ss3WxpJ2PlrY0ZPUQUa1UnvDt2PrRBDBLhsQ==",
       "requires": {
         "cheerio": "latest",
         "got": "11.8.2"

--- a/package.json
+++ b/package.json
@@ -212,7 +212,7 @@
     "bytebuffer": "^5.0.1",
     "chart.js": "^3.8.0",
     "chartjs-plugin-datalabels": "^2.0.0",
-    "currency-converter-lt": "^1.2.4",
+    "currency-converter-lt": "^1.3.0",
     "custom-electron-titlebar": "^4.1.0",
     "electron-debug": "^3.2.0",
     "electron-dl": "^3.3.0",


### PR DESCRIPTION
Currency converter use google query and
result may be different based on location
In Russia (probably not only here) amount looks like "69 420,55". 
Because of the space between thousands and hundreds, CC v1.2.4 cuts
right part and returns only "69". Which leads to the wrong prices.
In v1.3.0 google query was updated and now have fixed location