### PR TITLE
Fix download links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@
 
 This is the latest stable version and can be downloaded from the [releases](https://github.com/nombersDev/casemove/releases) page, or directly from:
 
-- [Windows - (Casemove-2.2.1)](https://github.com/nombersDev/casemove/releases/download/v2.1.1/Casemove-Setup-2.2.1.exe)
+- [Windows - (Casemove-2.2.1)](https://github.com/nombersDev/casemove/releases/download/v2.2.1/Casemove-Setup-2.2.1.exe)
 - [Mac - (Casemove-2.2.1)](https://github.com/nombersDev/casemove/releases/download/v2.2.1/Casemove-2.2.1.dmg)
 - [Mac ARM 64 (M1) - (Casemove-2.2.1)](https://github.com/nombersDev/casemove/releases/download/v2.2.1/Casemove-2.2.1-arm64.dmg)
-- [Linux AppImage - (Casemove-2.2.1)](https://github.com/nombersDev/casemove/releases/download/v2.2.1/casemove-2.2.1.zip)
+- [Linux .deb - (Casemove-2.2.1)](https://github.com/nombersDev/casemove/releases/download/v2.2.1/casemove_2.2.1_amd64.deb)
 
 
 


### PR DESCRIPTION
The download links are broken for v2.2.1:
- Windows: 404 since the version number in the URL is wrong.
- Linx: 404 since there is no AppImage built, but a .deb file.
