### PR TITLE
Add more build targets for Linux and FreeBSD

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,13 @@
     },
     "linux": {
       "target": [
-        "deb"
+        "deb",
+        "rpm",
+        "pacman",
+        "freebsd",
+        "AppImage",
+        "flatpak",
+        "snap"
       ],
       "category": "Development"
     },


### PR DESCRIPTION
Personally, I don't use Debian-based systems, so I would like to propose to add more build targets for Linux and FreeBSD.

In case you don't want to provide pacman-compatible, and rpm-compatible builds, please provide at least AppImage/Flatpak. They will run on nearly any Linux machine.