### PR TITLE
fixed auto-updater downloading .dmg instead of .deb on linux

### DIFF
--- a/src/main/scripts/versionHelper.tsx
+++ b/src/main/scripts/versionHelper.tsx
@@ -27,7 +27,7 @@ async function getGithubVersion(platform: string): Promise<GithubResponse> {
 
               case 'linux':
                 value.assets.forEach((element) => {
-                  if (element.name.includes('.dmg')) {
+                  if (element.name.includes('.deb')) {
                     downloadLink = element.browser_download_url;
                   }
                 });


### PR DESCRIPTION
noticed that the auto-updater on linux downloaded the .dmg instead of the .deb, this fixed it for me 